### PR TITLE
feat: add Config.Variables to be added to kong.Vars

### DIFF
--- a/king.go
+++ b/king.go
@@ -20,6 +20,7 @@ type Config struct {
 	Description  string
 	BuildInfo    *BuildInfo
 	ConfigPaths  []string
+	Variables    map[string]string
 	FileResolver FileResolver
 }
 
@@ -39,6 +40,10 @@ func DefaultOptions(c Config) []kong.Option {
 
 	vars := kong.Vars{
 		configPathsKey: c.pathString(),
+	}
+
+	for k, v := range c.Variables {
+		vars[k] = v
 	}
 
 	if c.BuildInfo != nil {


### PR DESCRIPTION
This enables the use of variable interpolation and default values with kong:
```go
	hostname, _ := os.Hostname()

	app := kong.Parse(&cli, king.DefaultOptions(
		king.Config{
			Name:        "...",
			Description: "...",
			Variables: map[string]string{
				"hostname":  hostname,
			},
		},
	)...)
```

```go
type myCommand struct {
	Hostname string `help:"Hostname ...." default:"${hostname}"`
}
```

